### PR TITLE
Support XDG directory specification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,6 +319,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -547,15 +568,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
-]
-
-[[package]]
-name = "home"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
-dependencies = [
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -895,6 +907,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "password-hash"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1012,11 +1030,31 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall 0.2.16",
+ "thiserror",
 ]
 
 [[package]]
@@ -1284,9 +1322,9 @@ dependencies = [
  "clap",
  "console",
  "dialoguer",
+ "dirs",
  "fs2",
  "hex",
- "home",
  "indicatif",
  "itertools",
  "once_cell",
@@ -1333,7 +1371,7 @@ checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "rustix",
  "windows-sys 0.45.0",
 ]

--- a/crates/svm-rs/Cargo.toml
+++ b/crates/svm-rs/Cargo.toml
@@ -27,7 +27,7 @@ required-features = ["solc"]
 [dependencies]
 fs2 = "0.4"
 hex = "0.4"
-home = "0.5"
+dirs = "5.0"
 once_cell = "1.17"
 reqwest = { version = "0.11", default-features = false, features = ["json"] }
 semver = { version = "1.0", features = ["serde"] }
@@ -50,7 +50,7 @@ tokio = { version = "1.28", features = ["rt-multi-thread", "macros"], optional =
 zip = "0.6"
 
 [build-dependencies]
-home = "0.5"
+dirs = "5.0"
 
 [dev-dependencies]
 rand = "0.8"

--- a/crates/svm-rs/src/bin/svm-bin/main.rs
+++ b/crates/svm-rs/src/bin/svm-bin/main.rs
@@ -23,7 +23,7 @@ enum SolcVm {
 async fn main() -> anyhow::Result<()> {
     let opt = SolcVm::parse();
 
-    svm_lib::setup_home()?;
+    svm_lib::setup_data_dir()?;
 
     match opt {
         SolcVm::List => {


### PR DESCRIPTION
Adding support to a [widely adopted standard](https://wiki.archlinux.org/title/XDG_Base_Directory) for user-specific application configuration/data files and directories, aimed at uncluttering the user's home directory.


~/.skm still works if that directory already exists, for backwards compatibility. If it does not exist, then the updated code will follow specification values.

